### PR TITLE
Update example in Readme to current Kaleidoscope practice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ To use the plugin, include the header, and tell the firmware to use it:
 ```c++
 #include <Kaleidoscope-LEDEffect-DigitalRain.h>
 
+KALEIDOSCOPE_INIT_PLUGINS(
+  LEDDigitalRainEffect
+);
+
 void setup() {
-  Kaleidoscope.use(&LEDDigitalRainEffect);
+  Kaleidoscope.setup();
 
   // Optionally adjust the configuration
   LEDDigitalRainEffect.DROP_TICKS = 22; // Make the rain fall faster
 
-  Kaleidoscope.setup();
+  LEDDigitalRainEffect.activate();
 }
 ```
 


### PR DESCRIPTION
Updates the README to represent Kaleidoscope's change from "Kaleidoscope.use". Responds to issue #5 .