### PR TITLE
Refactor in preparation for merge to Kaleidoscope

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,36 +20,55 @@ void setup() {
   Kaleidoscope.setup();
 
   // Optionally adjust the configuration
-  LEDDigitalRainEffect.DROP_MS = 140; // Make the rain fall faster
+  LEDDigitalRainEffect.setDropMs(260); // Make the rain fall more slowly
+  LEDDigitalRainEffect.setColorChannel(LEDDigitalRainEffect.ColorChannel::BLUE);
 
+  // Optionally switch this LED mode on at startup
   LEDDigitalRainEffect.activate();
 }
 ```
 
 ## Plugin methods
 
-The plugin provides the `LEDDigitalRainEffect` object, which has no public methods,
-outside of those provided by all LED modes.
+The plugin provides the `LEDDigitalRainEffect` object,
+which has various public getters and setters for configuration,
+as well as the methods associated with all LED mode plugins.
 
-## Configuration
+### Configuration
 
-A few properties are exposed for configuration.
-For their full documentation, see the [header file](src/Kaleidoscope-LEDEffect-DigitalRain.h),
-and for the defaults, see the [implementation file](src/Kaleidoscope-LEDEffect-DigitalRain.cpp).
+For full documentation and defaults, see the [header file](src/Kaleidoscope-LEDEffect-DigitalRain.h).
 
-- `LEDDigitalRainEffect.DECAY_MS`:
-  number of milliseconds it takes for a raindrop to decay from full intensity
-- `LEDDigitalRainEffect.DROP_MS`:
-  number of milliseconds before digital raindrops fall one row
-- `LEDDigitalRainEffect.NEW_DROP_PROBABILITY`:
-  inverse probability of a new raindrop appearing at the top of each column,
+- `LEDDigitalRainEffect.getDecayMs()`,
+  `LEDDigitalRainEffect.setDecayMs(uint16_t)`:
+  get or set the number of milliseconds it takes for a raindrop
+  to decay from full intensity
+- `LEDDigitalRainEffect.getDropMs()`,
+  `LEDDigitalRainEffect.setDropMs(uint16_t)`:
+  get or set the number of milliseconds before digital raindrops fall one row
+- `LEDDigitalRainEffect.getNewDropProbability()`,
+  `LEDDigitalRainEffect.setNewDropProbability(uint8_t)`:
+  get or set the *inverse* probability
+  of a new raindrop appearing at the top of each column,
   each time drops fall
-- `LEDDigitalRainEffect.PURE_GREEN_INTENSITY`:
-  this allows the time ratio of tints vs shades of green to be controlled
-- `LEDDigitalRainEffect.MAXIMUM_BRIGHTNESS_BOOST`:
-  the maximum lightness of a pixel, above pure green
-- `LEDDigitalRainEffect.COLOR_CHANNEL`:
-  colour channel to use, allowing green to be overridden with red or blue
+- `LEDDigitalRainEffect.getTintShadeRatio()`,
+  `LEDDigitalRainEffect.setTintShadeRatio(uint8_t)`:
+  get or set the intensity level (0 to 255)
+  at which pure green should be output;
+  this allows the timeshare ratio of tints vs shades of green to be controlled,
+  where `0` would mean all tints and `255` would mean all shades
+- `LEDDigitalRainEffect.getMaximumTint()`,
+  `LEDDigitalRainEffect.setMaximumTint(uint8_t)`:
+  get or set the maximum tint of a pixel,
+  where `0` would mean nothing brighter than pure green,
+  or `255` would mean tint all the way to pure white
+- `LEDDigitalRainEffect.getColorChannel()`,
+  `LEDDigitalRainEffect.setColorChannel(ColorChannel)`:
+  color channel to use, allowing green to be overridden with red or blue
+
+#### Color channels
+
+Color channels are identified with
+the `LEDDigitalRainEffect.ColorChannel` enum class.
 
 ## Dependencies
 

--- a/src/Kaleidoscope-LEDEffect-DigitalRain.cpp
+++ b/src/Kaleidoscope-LEDEffect-DigitalRain.cpp
@@ -53,7 +53,7 @@ void LEDDigitalRainEffect::TransientLEDMode::update() {
         // If this pixel is on the bottom row and bright,
         // allow it to start decaying
         if (row == rows - 1 && map_[col][row] == 0xff) {
-          map_[col][row]--;
+          --map_[col][row];
         }
 
         // Check if the pixel above is bright

--- a/src/Kaleidoscope-LEDEffect-DigitalRain.cpp
+++ b/src/Kaleidoscope-LEDEffect-DigitalRain.cpp
@@ -1,104 +1,108 @@
 #include <Kaleidoscope-LEDEffect-DigitalRain.h>
 #include <stdlib.h>
 
-namespace kaleidoscope { namespace plugin {
-	uint16_t LEDDigitalRainEffect::DECAY_MS = 2000;
-	uint16_t LEDDigitalRainEffect::DROP_MS = 180;
-	uint8_t LEDDigitalRainEffect::NEW_DROP_PROBABILITY = 18;
-	uint8_t LEDDigitalRainEffect::PURE_GREEN_INTENSITY = 0xd0;
-	uint8_t LEDDigitalRainEffect::MAXIMUM_BRIGHTNESS_BOOST = 0xc0;
-	uint8_t LEDDigitalRainEffect::COLOR_CHANNEL = 1;
+namespace kaleidoscope {
+namespace plugin {
 
-	void LEDDigitalRainEffect::update(void) {
-		uint8_t col;
-		uint8_t row;
+void LEDDigitalRainEffect::TransientLEDMode::update(void) {
+  static constexpr uint8_t rows = Runtime.device().matrix_rows;
+  static constexpr uint8_t cols = Runtime.device().matrix_columns;
 
-		// By how much intensity should each pixel decay,
-		// based on how much time has passed since we last ran?
-		uint8_t decayAmount = 0xff * (Runtime.millisAtCycleStart() - previousTimestamp) / DECAY_MS;
+  uint8_t col;
+  uint8_t row;
 
-		// Decay intensities and possibly make new raindrops
-		for (col = 0; col < COLS; col++) {
-			for (row = 0; row < ROWS; row++) {
-				if (row == 0 && justDropped && rand() < RAND_MAX / NEW_DROP_PROBABILITY) {
-					// This is the top row, pixels have just fallen,
-					// and we've decided to make a new raindrop in this column
-					map[col][row] = 0xff;
-				} else if (map[col][row] > 0 && map[col][row] < 0xff) {
-					// Pixel is neither full brightness nor totally dark;
-					// decay it
-					if (map[col][row] <= decayAmount) {
-						map[col][row] = 0;
-					} else {
-						map[col][row] -= decayAmount;
-					}
-				}
+  // By how much intensity should each pixel decay,
+  // based on how much time has passed since we last ran?
+  uint8_t decayAmount = 0xff * (Runtime.millisAtCycleStart() - previous_timestamp_) / parent_->decay_ms_;
 
-				// Set the colour for this pixel
-				::LEDControl.setCrgbAt(KeyAddr(row, col), getColorFromIntensity(map[col][row]));
-			}
-		}
+  // Decay intensities and possibly make new raindrops
+  for (col = 0; col < cols; col++) {
+    for (row = 0; row < rows; row++) {
+      if (row == 0 && just_dropped_ && rand() < RAND_MAX / parent_->new_drop_probability_) {
+        // This is the top row, pixels have just fallen,
+        // and we've decided to make a new raindrop in this column
+        map_[col][row] = 0xff;
+      } else if (map_[col][row] > 0 && map_[col][row] < 0xff) {
+        // Pixel is neither full intensity nor totally dark;
+        // decay it
+        if (map_[col][row] <= decayAmount) {
+          map_[col][row] = 0;
+        } else {
+          map_[col][row] -= decayAmount;
+        }
+      }
 
-		// Drop the raindrops one row periodically
-		if (Runtime.hasTimeExpired(dropStartTimestamp, DROP_MS)) {
-			// Remember for next time that this just happened
-			justDropped = true;
+      // Set the colour for this pixel
+      ::LEDControl.setCrgbAt(KeyAddr(row, col), get_color_from_intensity_(map_[col][row]));
+    }
+  }
 
-			// Reset the timestamp
-			dropStartTimestamp = Runtime.millisAtCycleStart();
+  // Drop the raindrops one row periodically
+  if (Runtime.hasTimeExpired(drop_start_timestamp_, parent_->drop_ms_)) {
+    // Remember for next time that this just happened
+    just_dropped_ = true;
 
-			// Remember for next tick that we just dropped
-			justDropped = true;
+    // Reset the timestamp
+    drop_start_timestamp_ = Runtime.millisAtCycleStart();
 
-			for (row = ROWS - 1; row > 0; row--) {
-				for (col = 0; col < COLS; col++) {
-					// If this pixel is on the bottom row and bright,
-					// allow it to start decaying
-					if (row == ROWS - 1 && map[col][row] == 0xff) {
-						map[col][row]--;
-					}
+    // Remember for next tick that we just dropped
+    just_dropped_ = true;
 
-					// Check if the pixel above is bright
-					if (map[col][row - 1] == 0xff) {
-						// Allow old bright pixel to decay
-						map[col][row - 1]--;
+    for (row = rows - 1; row > 0; row--) {
+      for (col = 0; col < cols; col++) {
+        // If this pixel is on the bottom row and bright,
+        // allow it to start decaying
+        if (row == rows - 1 && map_[col][row] == 0xff) {
+          map_[col][row]--;
+        }
 
-						// Make this pixel bright
-						map[col][row] = 0xff;
-					}
-				}
-			}
-		} else {
-			justDropped = false;
-		}
+        // Check if the pixel above is bright
+        if (map_[col][row - 1] == 0xff) {
+          // Allow old bright pixel to decay
+          map_[col][row - 1]--;
 
-		// Update previous timestamp variable to now
-		// so we can tell how much time has passed next time we run
-		previousTimestamp = Runtime.millisAtCycleStart();
-	}
+          // Make this pixel bright
+          map_[col][row] = 0xff;
+        }
+      }
+    }
+  } else {
+    just_dropped_ = false;
+  }
 
-	cRGB LEDDigitalRainEffect::getColorFromIntensity(uint8_t intensity) {
-		uint8_t boost;
+  // Update previous timestamp variable to now
+  // so we can tell how much time has passed next time we run
+  previous_timestamp_ = Runtime.millisAtCycleStart();
+}
 
-		// At high intensities start at light green
-		// but drop off very quickly to full green
-		if (intensity > PURE_GREEN_INTENSITY) {
-			boost = (uint8_t) ((uint16_t) MAXIMUM_BRIGHTNESS_BOOST
-					* (intensity - PURE_GREEN_INTENSITY)
-					/ (0xff - PURE_GREEN_INTENSITY));
-			return getColorFromComponents(0xff, boost);
-		}
-		return getColorFromComponents((uint8_t) ((uint16_t) 0xff * intensity / PURE_GREEN_INTENSITY), 0);
-	}
+cRGB LEDDigitalRainEffect::TransientLEDMode::get_color_from_intensity_(uint8_t intensity) {
+  uint8_t boost;
 
-	cRGB LEDDigitalRainEffect::getColorFromComponents(uint8_t primary, uint8_t secondary) {
-		switch (COLOR_CHANNEL) {
-			case 0: return CRGB(primary, secondary, secondary);
-			case 1: return CRGB(secondary, primary, secondary);
-			case 2: return CRGB(secondary, secondary, primary);
-			default: return CRGB(0, 0, 0);
-		}
-	}
-}}
+  // At high intensities start at light green
+  // but drop off very quickly to full green
+  if (intensity > parent_->tint_shade_ratio_) {
+    boost = (uint8_t)((uint16_t) parent_->maximum_tint_
+                      * (intensity - parent_->tint_shade_ratio_)
+                      / (0xff - parent_->tint_shade_ratio_));
+    return get_color_from_components_(0xff, boost);
+  }
+  return get_color_from_components_((uint8_t)((uint16_t) 0xff * intensity / parent_->tint_shade_ratio_), 0);
+}
+
+cRGB LEDDigitalRainEffect::TransientLEDMode::get_color_from_components_(uint8_t primary, uint8_t secondary) {
+  switch (parent_->color_channel_) {
+  case LEDDigitalRainEffect::ColorChannel::RED:
+    return CRGB(primary, secondary, secondary);
+  case LEDDigitalRainEffect::ColorChannel::GREEN:
+    return CRGB(secondary, primary, secondary);
+  case LEDDigitalRainEffect::ColorChannel::BLUE:
+    return CRGB(secondary, secondary, primary);
+  default:
+    return CRGB(0, 0, 0);
+  }
+}
+
+}
+}
 
 kaleidoscope::plugin::LEDDigitalRainEffect LEDDigitalRainEffect;

--- a/src/Kaleidoscope-LEDEffect-DigitalRain.cpp
+++ b/src/Kaleidoscope-LEDEffect-DigitalRain.cpp
@@ -4,7 +4,7 @@
 namespace kaleidoscope {
 namespace plugin {
 
-void LEDDigitalRainEffect::TransientLEDMode::update(void) {
+void LEDDigitalRainEffect::TransientLEDMode::update() {
   static constexpr uint8_t rows = Runtime.device().matrix_rows;
   static constexpr uint8_t cols = Runtime.device().matrix_columns;
 

--- a/src/Kaleidoscope-LEDEffect-DigitalRain.h
+++ b/src/Kaleidoscope-LEDEffect-DigitalRain.h
@@ -3,109 +3,170 @@
 #include "kaleidoscope/Runtime.h"
 #include <Kaleidoscope-LEDControl.h>
 
-namespace kaleidoscope { namespace plugin {
-	class LEDDigitalRainEffect : public LEDMode {
-		public:
-			LEDDigitalRainEffect(void) {}
+namespace kaleidoscope {
+namespace plugin {
 
-			/**
-			 * Number of milliseconds it takes for a drop to decay
-			 * from full intensity to zero.
-			 */
-			static uint16_t DECAY_MS;
+class LEDDigitalRainEffect : public Plugin,
+  public LEDModeInterface,
+  public AccessTransientLEDMode {
+ public:
+  LEDDigitalRainEffect(void) {}
 
-			/**
-			 * Number of milliseconds before raindrops fall.
-			 */
-			static uint16_t DROP_MS;
+  /**
+   * Color channel enum.
+   */
+  enum class ColorChannel {RED, GREEN, BLUE};
 
-			/**
-			 * Probability divisor for new drops.
-			 *
-			 * The inverse of this number (1/n) gives the probability
-			 * each time DROP_MS has elapsed
-			 * that a new raindrop will appear in a given column.
-			 */
-			static uint8_t NEW_DROP_PROBABILITY;
+  /**
+   * Get or set the number milliseconds it takes for a drop to decay
+   * from full intensity to zero.
+   */
+  uint16_t getDecayMs(void) {
+    return decay_ms_;
+  }
+  void setDecayMs(uint16_t decayMs) {
+    decay_ms_ = decayMs;
+  }
 
-			/**
-			 * Intensity at which full green is used.
-			 *
-			 * When a pixel is at this intensity,
-			 * full green with no red nor blue is used.
-			 * Above this intensity red and blue are added
-			 * to lighten the colour.
-			 */
-			static uint8_t PURE_GREEN_INTENSITY;
+  /**
+   * Get or set the number of milliseconds before raindrops fall.
+   */
+  uint16_t getDropMs(void) {
+    return drop_ms_;
+  }
+  void setDropMs(uint16_t dropMs) {
+    drop_ms_ = dropMs;
+  }
 
-			/**
-			 * Maximum brightness boost.
-			 *
-			 * The maximum brightness boost added to pure green
-			 * when a pixel is at full intensity.
-			 *
-			 * 0xff would give full white for full-intensity pixels,
-			 * while zero would give pure green for all intensities
-			 * above PURE_GREEN_INTENSITY.
-			 */
-			static uint8_t MAXIMUM_BRIGHTNESS_BOOST;
+  /**
+   * Get or set the probability divisor for new drops.
+   *
+   * The inverse of this number (1/n) gives the probability
+   * each time raindrops fall one row (see getDropMs/setDropMs) has elapsed
+   * that a new raindrop will appear in a given column.
+   */
+  uint8_t getNewDropProbability(void) {
+    return new_drop_probability_;
+  }
+  void setNewDropProbability(uint8_t newDropProbability) {
+    new_drop_probability_ = newDropProbability;
+  }
 
-			/**
-			 * Colour channel.
-			 *
-			 * This can be changed to set the colour
-			 * to red (0), green (1), or blue (2).
-			 */
-			static uint8_t COLOR_CHANNEL;
+  /**
+   * Get or set the intensity at which we display neither a tint nor shade.
+   *
+   * Intensity falls from 255 to 0.
+   *
+   * When a pixel's intensity level reaches this value,
+   * full green with no red nor blue is used.
+   * Above this intensity red and blue are added
+   * to tint the color towards white,
+   * and below this intensity the green channel is dimmed.
+   */
+  uint8_t getTintShadeRatio(void) {
+    return tint_shade_ratio_;
+  }
+  void setTintShadeRatio(uint8_t tintShadeRatio) {
+    tint_shade_ratio_ = tintShadeRatio;
+  }
 
-		protected:
-			virtual void update(void) final;
+  /**
+   * Get or set the maximum tint.
+   *
+   * This is the maximum tint of a pixel,
+   * used when it is at full intensity.
+   * More specifically, this is the maximum value
+   * which will be in the red and blue channels.
+   *
+   * As such, 0xff would give full white for full-intensity pixels,
+   * while zero would give pure green for all intensities
+   * at and above the intensity described by the tint/shade ratio.
+   */
+  uint8_t getMaximumTint(void) {
+    return maximum_tint_;
+  }
+  void setMaximumTint(uint8_t maximumTint) {
+    maximum_tint_ = maximumTint;
+  }
 
-		private:
-			/**
-			 * Timer at start of drop cycle.
-			 */
-			uint32_t dropStartTimestamp = 0;
+  /**
+   * Get or set the color channel.
+   *
+   * This can be changed to set the color
+   * to red, green, or blue.
+   */
+  ColorChannel getColorChannel(void) {
+    return color_channel_;
+  }
+  void setColorChannel(ColorChannel colorChannel) {
+    color_channel_ = colorChannel;
+  }
 
-			/**
-			 * Timer at previous tick.
-			 */
-			uint32_t previousTimestamp = 0;
+  class TransientLEDMode : public LEDMode {
+   public:
+    TransientLEDMode(const LEDDigitalRainEffect *parent)
+      : parent_(parent) {};
 
-			/**
-			 * Keep track of whether raindrops fell on the last
-			 * tick.
-			 */
-			bool justDropped = false;
+   protected:
+    virtual void update() final;
 
-			/**
-			 * Number of columns
-			 */
-			uint8_t COLS = Runtime.device().matrix_columns;
+   private:
+    /**
+     * Pointer to parent class, which houses configuration.
+     */
+    const LEDDigitalRainEffect *parent_;
 
-			/**
-			 * Number of rows
-			 */
-			uint8_t ROWS = Runtime.device().matrix_rows;
+    /**
+     * Timer at start of drop cycle.
+     */
+    uint32_t drop_start_timestamp_ = 0;
 
-			/**
-			 * Map of intensities for each pixel.
-			 *
-			 * Intensity 0xff stays for a full DROP_MS,
-			 * then linearly drops off to zero with time.
-			 */
-			uint8_t map[Runtime.device().matrix_columns][Runtime.device().matrix_rows] = {{0}};
+    /**
+     * Timer at previous tick.
+     */
+    uint32_t previous_timestamp_ = 0;
 
-			/**
-			 * Get colour from intensity.
-			 */
-			cRGB getColorFromIntensity(uint8_t intensity);
+    /**
+     * Keep track of whether raindrops fell on the last
+     * tick.
+     */
+    bool just_dropped_ = false;
 
-			/**
-			 * Get colour from primary and secondary components.
-			 */
-			cRGB getColorFromComponents(uint8_t primary, uint8_t secondary);
-	};
-}}
+    /**
+     * Map of intensities for each pixel.
+     *
+     * Intensity 0xff stays for a full drop_ms_,
+     * then linearly drops off to zero with time.
+     */
+    uint8_t map_[Runtime.device().matrix_columns][Runtime.device().matrix_rows] = {{0}};
+
+    /**
+     * Get color from intensity.
+     */
+    cRGB get_color_from_intensity_(uint8_t intensity);
+
+    /**
+     * Get color from primary and secondary components.
+     */
+    cRGB get_color_from_components_(uint8_t primary, uint8_t secondary);
+
+    friend class LEDDigitalRainEffect;
+  };
+
+ private:
+  /**
+   * Values which the public accessors get and set,
+   * and their defaults.
+   */
+  uint16_t decay_ms_ = 2000;
+  uint16_t drop_ms_ = 180;
+  uint8_t new_drop_probability_ = 18;
+  uint8_t tint_shade_ratio_ = 0xd0;
+  uint8_t maximum_tint_ = 0xc0;
+  ColorChannel color_channel_ = ColorChannel::GREEN;
+};
+
+}
+}
 
 extern kaleidoscope::plugin::LEDDigitalRainEffect LEDDigitalRainEffect;

--- a/src/Kaleidoscope-LEDEffect-DigitalRain.h
+++ b/src/Kaleidoscope-LEDEffect-DigitalRain.h
@@ -10,7 +10,7 @@ class LEDDigitalRainEffect : public Plugin,
   public LEDModeInterface,
   public AccessTransientLEDMode {
  public:
-  LEDDigitalRainEffect(void) {}
+  LEDDigitalRainEffect() {}
 
   /**
    * Color channel enum.
@@ -21,7 +21,7 @@ class LEDDigitalRainEffect : public Plugin,
    * Get or set the number milliseconds it takes for a drop to decay
    * from full intensity to zero.
    */
-  uint16_t getDecayMs(void) {
+  uint16_t getDecayMs() {
     return decay_ms_;
   }
   void setDecayMs(uint16_t decayMs) {
@@ -31,7 +31,7 @@ class LEDDigitalRainEffect : public Plugin,
   /**
    * Get or set the number of milliseconds before raindrops fall.
    */
-  uint16_t getDropMs(void) {
+  uint16_t getDropMs() {
     return drop_ms_;
   }
   void setDropMs(uint16_t dropMs) {
@@ -45,7 +45,7 @@ class LEDDigitalRainEffect : public Plugin,
    * each time raindrops fall one row (see getDropMs/setDropMs) has elapsed
    * that a new raindrop will appear in a given column.
    */
-  uint8_t getNewDropProbability(void) {
+  uint8_t getNewDropProbability() {
     return new_drop_probability_;
   }
   void setNewDropProbability(uint8_t newDropProbability) {
@@ -63,7 +63,7 @@ class LEDDigitalRainEffect : public Plugin,
    * to tint the color towards white,
    * and below this intensity the green channel is dimmed.
    */
-  uint8_t getTintShadeRatio(void) {
+  uint8_t getTintShadeRatio() {
     return tint_shade_ratio_;
   }
   void setTintShadeRatio(uint8_t tintShadeRatio) {
@@ -82,7 +82,7 @@ class LEDDigitalRainEffect : public Plugin,
    * while zero would give pure green for all intensities
    * at and above the intensity described by the tint/shade ratio.
    */
-  uint8_t getMaximumTint(void) {
+  uint8_t getMaximumTint() {
     return maximum_tint_;
   }
   void setMaximumTint(uint8_t maximumTint) {
@@ -95,7 +95,7 @@ class LEDDigitalRainEffect : public Plugin,
    * This can be changed to set the color
    * to red, green, or blue.
    */
-  ColorChannel getColorChannel(void) {
+  ColorChannel getColorChannel() {
     return color_channel_;
   }
   void setColorChannel(ColorChannel colorChannel) {


### PR DESCRIPTION
See #12 

- Use TransientLEDMode
- Use Kaleidoscope naming scheme for private properties (snake case with trailing tail)
- Add public getters and setters for configuration values
- Use an enum class for colour channels
- Use US spelling for 'color' throughout (docs/comments as well as labels)
- Move cols and rows totals to be local to the update method, and constexpr
- Use Kaleidoscope code style
        `astyle --style=google --unpad-paren --pad-header --pad-oper --indent-classes --indent=spaces=2 *`
- Rename some configuration values:
  - pure green intensity -> tint/shade ratio
  - maximum brightness boost -> maximum tint

@algernon, please review!

Anything else to change?